### PR TITLE
Updating username and password

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
 


### PR DESCRIPTION
- To use an PyPI API token, the username needs to be `__token__`, so this change hard codes this.
- Renamed the `PYPI_PASSWORD` to `PYPI_TOKEN` as this is the API token, not a password.
- Upped the setup python action to v5 to remove a deprecation warning